### PR TITLE
feat: add following feed auto-switch extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Node dependencies
+node_modules/
+
+# Build output
+/dist/
+
+# OS files
+.DS_Store
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # x-following-tab
-Automatically switch to the following tab on the X homepage
+
+Chrome extension that automatically switches to the Following tab on the X (formerly Twitter) homepage.
+
+## Installation
+
+1. Clone or download this repository.
+2. In Chrome, open `chrome://extensions`.
+3. Enable **Developer mode**.
+4. Choose **Load unpacked** and select this folder.
+5. Visit [x.com](https://x.com). If the **For you** feed loads, the extension redirects you to **Following**.
+
+## Development
+
+The extension source lives in `manifest.json` and `content.js`.
+
+To lint the extension with [web-ext](https://github.com/mozilla/web-ext):
+
+```bash
+npx web-ext lint
+```
+
+## License
+
+[MIT](LICENSE)

--- a/content.js
+++ b/content.js
@@ -1,0 +1,24 @@
+(function() {
+  function redirectToFollowing() {
+    const url = new URL(window.location.href);
+    const isX = url.hostname === 'x.com' || url.hostname === 'twitter.com';
+    const isHome = url.pathname === '/' || url.pathname === '/home';
+    const isFollowing = url.searchParams.get('f') === '1';
+
+    if (isX && isHome && !isFollowing) {
+      url.pathname = '/home';
+      url.searchParams.set('f', '1');
+      window.location.replace(url.toString());
+    }
+  }
+
+  redirectToFollowing();
+
+  const pushState = history.pushState;
+  history.pushState = function() {
+    pushState.apply(this, arguments);
+    redirectToFollowing();
+  };
+
+  window.addEventListener('popstate', redirectToFollowing);
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "X Auto Following Feed",
+  "version": "1.0.0",
+  "description": "Automatically switch to the Following feed on X (formerly Twitter).",
+  "content_scripts": [
+    {
+      "matches": ["https://x.com/*", "https://twitter.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "host_permissions": ["https://x.com/*", "https://twitter.com/*"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "x-following-tab@example.com"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create Chrome extension that redirects X home timeline to the Following tab
- document installation and add web-ext lint instructions
- add standard .gitignore

## Testing
- `npx --yes web-ext lint`


------
https://chatgpt.com/codex/tasks/task_e_6898dfbbaaf4832a983c1ec23523d355